### PR TITLE
T274798 include all unillustrated articles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+venv: requirements.txt
+	test -d venv || virtualenv --python=$(shell which python3) venv
+	. venv/bin/activate; pip install -Ur requirements.txt;
+
+test:	venv
+	. venv/bin/activate; pytest --cov etl

--- a/algorithm.ipynb
+++ b/algorithm.ipynb
@@ -596,7 +596,6 @@
     "    data_small[wiki]['selected']=selected\n",
     "    data_small[wiki]['notes']=notes\n",
     "    data_small[wiki]['good_interlinks']=wikis\n",
-    "    data_small[wiki]=data_small[wiki][data_small[wiki]['selected'].astype(str).ne('None')]\n",
     "    #print(\"total number of articles: \"+str(total[wiki]))\n",
     "    #print(\"number of unillustrated articles: \"+str(len(qids_and_properties[wiki])))\n",
     "    #print(\"number of articles with at least 1 recommendation: \"+str(len(data_small[wiki])))\n",

--- a/conftest.py
+++ b/conftest.py
@@ -10,10 +10,19 @@ def raw_data(spark_session):
                 "0",
                 "Q1234",
                 "44444",
-                "Some page",
+                "Some page with suggestions",
                 '[{"image": "image1.jpg", "rating": 2.0, "note": "image was found in the following Wikis: ruwiki"}]',
                 "arwiki",
                 "2020-12",
+            ),
+            (
+                "1",
+                "Q56789",
+                "55555",
+                "Some page with no suggestion",
+                None,
+                "arwiki",
+                "2020-12"
             )
         ],
         RawDataset.schema,

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,20 @@
+import pytest
+from etl.transform import RawDataset
+
+
+@pytest.fixture(scope="session")
+def raw_data(spark_session):
+    return spark_session.createDataFrame(
+        [
+            (
+                "0",
+                "Q1234",
+                "44444",
+                "Some page",
+                '[{"image": "image1.jpg", "rating": 2.0, "note": "image was found in the following Wikis: ruwiki"}]',
+                "arwiki",
+                "2020-12",
+            )
+        ],
+        RawDataset.schema,
+    )

--- a/ddl/external_imagerec_prod.hql
+++ b/ddl/external_imagerec_prod.hql
@@ -24,13 +24,15 @@ ROW FORMAT SERDE
   'org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe'
 WITH SERDEPROPERTIES (
   'field.delim'='\t',
-  'serialization.format'='\t')
+  'serialization.format'='\t',
+  'serialization.null.format'='""')
 STORED AS INPUTFORMAT
   'org.apache.hadoop.mapred.TextInputFormat'
 OUTPUTFORMAT
   'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'
 LOCATION
   'hdfs://analytics-hadoop/user/${hiveconf:username}/imagerec_prod/data';
+
 
 -- Update partition metadata
 MSCK REPAIR TABLE `imagerec_prod`;

--- a/etl/transform.py
+++ b/etl/transform.py
@@ -52,7 +52,7 @@ class ImageRecommendation:
             )
 
     def transform(self) -> DataFrame:
-        return (
+        with_recommendations = (
             self.dataFrame.where(~F.col("top_candidates").isNull())
             .withColumn(
                 "data",
@@ -73,22 +73,23 @@ class ImageRecommendation:
                 "confidence_rating",
                 "source",
             )
-            .union(
-                self.dataFrame.where(F.col("top_candidates").isNull())
-                .withColumnRenamed("wiki_db", "wiki")
-                .withColumn("image_id", F.lit(None))
-                .withColumn("confidence_rating", F.lit(None))
-                .withColumn("source", F.lit(None))
-                .select(
-                    "wiki",
-                    "page_id",
-                    "page_title",
-                    "image_id",
-                    "confidence_rating",
-                    "source",
-                )
+        )
+        without_recommendations = (
+            self.dataFrame.where(F.col("top_candidates").isNull())
+            .withColumnRenamed("wiki_db", "wiki")
+            .withColumn("image_id", F.lit(None))
+            .withColumn("confidence_rating", F.lit(None))
+            .withColumn("source", F.lit(None))
+            .select(
+                "wiki",
+                "page_id",
+                "page_title",
+                "image_id",
+                "confidence_rating",
+                "source",
             )
         )
+        return with_recommendations.union(without_recommendations)
 
 
 if __name__ == "__main__":

--- a/etl/transform.py
+++ b/etl/transform.py
@@ -53,7 +53,8 @@ class ImageRecommendation:
 
     def transform(self) -> DataFrame:
         return (
-            self.dataFrame.withColumn(
+            self.dataFrame.where(~F.col("top_candidates").isNull())
+            .withColumn(
                 "data",
                 F.explode(
                     F.from_json("top_candidates", RawDataset.recommendation_schema)
@@ -71,6 +72,21 @@ class ImageRecommendation:
                 "image_id",
                 "confidence_rating",
                 "source",
+            )
+            .union(
+                self.dataFrame.where(F.col("top_candidates").isNull())
+                .withColumnRenamed("wiki_db", "wiki")
+                .withColumn("image_id", F.lit(None))
+                .withColumn("confidence_rating", F.lit(None))
+                .withColumn("source", F.lit(None))
+                .select(
+                    "wiki",
+                    "page_id",
+                    "page_title",
+                    "image_id",
+                    "confidence_rating",
+                    "source",
+                )
             )
         )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+pytest==6.2.2
+pytest-spark==0.6.0
+pytest-cov==2.10.1

--- a/tests/test_etl.py
+++ b/tests/test_etl.py
@@ -1,0 +1,10 @@
+from etl.transform import RawDataset, ImageRecommendation
+
+
+def test_etl(raw_data):
+    assert raw_data.count() == 1
+
+    raw_data.show()
+    ddf = ImageRecommendation(raw_data).transform()
+    assert len(set(ddf.columns).difference({"wiki", "page_id", "page_title", "image_id", "confidence_rating", "source"})) == 0
+    assert ddf.count()

--- a/tests/test_etl.py
+++ b/tests/test_etl.py
@@ -2,9 +2,24 @@ from etl.transform import RawDataset, ImageRecommendation
 
 
 def test_etl(raw_data):
-    assert raw_data.count() == 1
+    assert raw_data.count() == 2
 
-    raw_data.show()
     ddf = ImageRecommendation(raw_data).transform()
-    assert len(set(ddf.columns).difference({"wiki", "page_id", "page_title", "image_id", "confidence_rating", "source"})) == 0
-    assert ddf.count()
+    assert (
+        len(
+            set(ddf.columns).difference(
+                {
+                    "wiki",
+                    "page_id",
+                    "page_title",
+                    "image_id",
+                    "confidence_rating",
+                    "source",
+                }
+            )
+        )
+        == 0
+    )
+
+    expected_num_records = 2
+    assert ddf.count() == expected_num_records


### PR DESCRIPTION
Raw data can contain records with NULL image_id.

The `ImageMatching` dataset should include all unillustrated articles,
with or without candidate matches.

This PR updates the algo code, and the production 
dataset ETL to account for this new behaviour. 

Articles with no matches will be saved with an empty
`top_candidates` field in the raw dataset. These records will
be stored with empty (`""`) `image_id`, `source`, `confidence_rating` fields
in prod data. An example of prod dataset with empty suggestions
can be found in `gmodena.imagerec_prod`.

## Example
```
hive (gmodena)> select count(*) from gmodena.imagerec_prod where image_id is not null;
104342
hive (gmodena)> select count(*) from gmodena.imagerec_prod where image_id is null;
39518
```

## Changelog
* `algorithm.ipynb` has been modified to save all articles 
that we consider unillustrated. 

* `etl/transform.py` has been updated to handle raw data records
 with an empty `top_candidates` field. 

* `ddl/external_imagerec_prod.hql` has been modified so that empty
 strings are formatted as `NULL` by Hive (and provide sql NULL semantic).
