### PR TITLE
T275685 automate pytest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,10 +17,17 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
+    - name: Install build dependencies
       run: |
         pip install -r requirements.txt
         pip install -e .
+    - name: Lint code with flake8
+      run: |
+        pip install flake8==3.8
+        # stop the build if there are Python syntax errors or undefined names in *.py files
+        flake8 *.py etl/ tests/ --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 *.py etl/ tests/ --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - uses: olafurpg/setup-scala@v10
       with:
         java-version: adopt@1.8

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.6, 3.7] # pyspark2.x supported python
+        python-version: [3.7, ] # pyspark2.x supported python
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
         java-version: adopt@1.8
     - name: Install Spark 
       run: |
-	make install_spark
+        make install_spark
     - name: Test with pytest
       run: |
-	make test
+        make test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,11 +33,7 @@ jobs:
         java-version: adopt@1.8
     - name: Install Spark 
       run: |
-        wget http://apachemirror.wuchna.com/spark/spark-2.4.7/spark-2.4.7-bin-hadoop2.7.tgz
-        tar -xzvf spark-2.4.7-bin-hadoop2.7.tgz
+	make install_spark
     - name: Test with pytest
       run: |
-        export SPARK_HOME=spark-2.4.7-bin-hadoop2.7/
-        export PYTHONPATH=$SPARK_HOME/python:$SPARK_HOME/python/lib/py4j-0.10.7-src.zip:$PYTHONPATH
-        export PATH=$PATH:$SPARK_HOME/bin:$SPARK_HOME/sbin 
-        pytest tests/
+	make test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,29 @@
+name: build
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 4
+      matrix:
+        python-version: [3.6, 3.7] # pyspark2.x supported python
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools>=41.0.0
+        pip install -r requirements.txt
+        pip install -e .
+    - name: Test with pytest
+      run: |
+        pip install pyspark==2.4
+        pytest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,9 @@ jobs:
     - name: Install dependencies
       run: |
         make venv
+    - name: Lint python files with flake8
+      run: |
+        make flake8
     - uses: olafurpg/setup-scala@v10
       with:
         java-version: adopt@1.8

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,23 +17,19 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install build dependencies
+    - name: Install dependencies
       run: |
-        pip install -r requirements.txt
-        pip install -e .
-    - name: Lint code with flake8
-      run: |
-        pip install flake8==3.8
-        # stop the build if there are Python syntax errors or undefined names in *.py files
-        flake8 *.py etl/ tests/ --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 *.py etl/ tests/ --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+        make venv
     - uses: olafurpg/setup-scala@v10
       with:
         java-version: adopt@1.8
-    - name: Install Spark 
+    - name: Install Apache Spark
       run: |
+        # This command will install vanilla spark under ./spark-2.4.7-bin-hadoop2.7
         make install_spark
     - name: Test with pytest
       run: |
+        export SPARK_HOME=$(pwd)/spark-2.4.7-bin-hadoop2.7
+        export PYTHONPATH=${SPARK_HOME}/python:${SPARK_HOME}/python/lib/py4j-0.10.7-src.zip:${PYTHONPATH}
+        export PATH=${PATH}:${SPARK_HOME}/bin:${SPARK_HOME}/sbin
         make test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.7, ] # pyspark2.x supported python
+        python-version: [3.7, ] 
 
     steps:
     - uses: actions/checkout@v1
@@ -19,11 +19,18 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        pip install setuptools>=41.0.0
         pip install -r requirements.txt
         pip install -e .
+    - uses: olafurpg/setup-scala@v10
+      with:
+        java-version: adopt@1.8
+    - name: Install Spark 
+      run: |
+        wget http://apachemirror.wuchna.com/spark/spark-2.4.7/spark-2.4.7-bin-hadoop2.7.tgz
+        tar -xzvf spark-2.4.7-bin-hadoop2.7.tgz
     - name: Test with pytest
       run: |
-        pip install pyspark==2.4
-        pytest
+        export SPARK_HOME=spark-2.4.7-bin-hadoop2.7/
+        export PYTHONPATH=$SPARK_HOME/python:$SPARK_HOME/python/lib/py4j-0.10.7-src.zip:$PYTHONPATH
+        export PATH=$PATH:$SPARK_HOME/bin:$SPARK_HOME/sbin 
+        pytest tests/

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,8 @@ spark_home := spark-${spark_version}-bin-hadoop${hadoop_version}
 spark_tgz_url := http://apachemirror.wuchna.com/spark/spark-${spark_version}/${spark_home}.tgz
 
 venv: requirements.txt
-	test -d venv || python -m venv venv
-	. venv/bin/activate; pip install -Ur requirements.txt;
+	test -d venv || python3 -m venv venv
+	. venv/bin/activate; pip3 install -Ur requirements.txt;
 
 install_spark:
 	test -d ${spark_home} || (wget ${spark_tgz_url}; tar -xzvf ${spark_home}.tgz)
@@ -14,11 +14,10 @@ clean_spark:
 	rm -r ${spark_home}; rm -rf ${spark_home}.tgz
 
 flake8:	venv
-	. venv/bin/activate
 	# stop the build if there are Python syntax errors or undefined names in *.py file
-	flake8 *.py etl/ tests/ --count --select=E9,F63,F7,F82 --show-source --statistics
+	. venv/bin/activate; flake8 *.py etl/ tests/ --count --select=E9,F63,F7,F82 --show-source --statistics
 	# exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-	flake8 *.py etl/ tests/ --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+	. venv/bin/activate; flake8 *.py etl/ tests/ --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
 test:	venv
 	. venv/bin/activate; pytest --cov etl tests/

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,24 @@
-spark_version = 2.4.7
-hadoop_version = 2.7
-spark_home = spark-${spark_version}-bin-hadoop${hadoop_version}
-spark_tgz_url = http://apachemirror.wuchna.com/spark/spark-${spark_version}/${spark_home}.tgz
+spark_version := 2.4.7
+hadoop_version := 2.7
+spark_home := spark-${spark_version}-bin-hadoop${hadoop_version}
+spark_tgz_url := http://apachemirror.wuchna.com/spark/spark-${spark_version}/${spark_home}.tgz
 
 venv: requirements.txt
-	test -d venv || python3 -m venv venv
-	. venv/bin/activate; pip3 install -Ur requirements.txt;
+	test -d venv || python -m venv venv
+	. venv/bin/activate; pip install -Ur requirements.txt;
 
 install_spark:
 	test -d ${spark_home} || (wget ${spark_tgz_url}; tar -xzvf ${spark_home}.tgz)
 
 clean_spark:
-	rm -r ${spark_home}
+	rm -r ${spark_home}; rm -rf ${spark_home}.tgz
 
-test:	install_spark	venv
+flake8:	venv
+	. venv/bin/activate
+	# stop the build if there are Python syntax errors or undefined names in *.py file
+	flake8 *.py etl/ tests/ --count --select=E9,F63,F7,F82 --show-source --statistics
+	# exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+	flake8 *.py etl/ tests/ --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+
+test:	venv
 	. venv/bin/activate; pytest --cov etl tests/

--- a/Makefile
+++ b/Makefile
@@ -4,14 +4,14 @@ spark_home = spark-${spark_version}-bin-hadoop${hadoop_version}
 spark_tgz_url = http://apachemirror.wuchna.com/spark/spark-${spark_version}/${spark_home}.tgz
 
 venv: requirements.txt
-	test -d venv || python -m venv venv
-	. venv/bin/activate; pip install -Ur requirements.txt;
+	test -d venv || python3 -m venv venv
+	. venv/bin/activate; pip3 install -Ur requirements.txt;
 
 install_spark:
-	test -d ${spark_version} || wget ${spark_tgz_url}; tar -xzvf ${spark_home}.tgz
+	test -d ${spark_home} || (wget ${spark_tgz_url}; tar -xzvf ${spark_home}.tgz)
 
 clean_spark:
 	rm -r ${spark_home}
 
 test:	install_spark	venv
-	. venv/bin/activate; pytest --cov etl
+	. venv/bin/activate; pytest --cov etl tests/

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,17 @@
+spark_version = 2.4.7
+hadoop_version = 2.7
+spark_home = spark-${spark_version}-bin-hadoop${hadoop_version}
+spark_tgz_url = http://apachemirror.wuchna.com/spark/spark-${spark_version}/${spark_home}.tgz
+
 venv: requirements.txt
-	test -d venv || virtualenv --python=$(shell which python3) venv
+	test -d venv || python -m venv venv
 	. venv/bin/activate; pip install -Ur requirements.txt;
 
-test:	venv
+install_spark:
+	test -d ${spark_version} || wget ${spark_tgz_url}; tar -xzvf ${spark_home}.tgz
+
+clean_spark:
+	rm -r ${spark_home}
+
+test:	install_spark	venv
 	. venv/bin/activate; pytest --cov etl

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![](https://github.com/mirrys/ImageMatching/workflows/build/badge.svg)
+
 # ImageMatching
 Image recommendation for unillustrated Wikipedia articles
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![](https://github.com/mirrys/ImageMatching/workflows/build/badge.svg)
+![](https://github.com/mirrys/ImageMatching/workflows/build/badge.svg?branch=main)
 
 # ImageMatching
 Image recommendation for unillustrated Wikipedia articles

--- a/etl/transform.py
+++ b/etl/transform.py
@@ -1,5 +1,5 @@
 from pyspark.sql import SparkSession
-from pyspark.sql.types import ArrayType, StructType, StringType, DoubleType, IntegerType
+from pyspark.sql.types import StructType, StringType, IntegerType
 from pyspark.sql import Column, DataFrame
 from pyspark.sql import functions as F
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pytest==6.2.2
 pytest-spark==0.6.0
 pytest-cov==2.10.1
+flake8==3.8.4

--- a/tests/test_etl.py
+++ b/tests/test_etl.py
@@ -1,4 +1,4 @@
-from etl.transform import RawDataset, ImageRecommendation
+from etl.transform import ImageRecommendation
 
 
 def test_etl(raw_data):


### PR DESCRIPTION
This PR adds a github action to lint (flake8) and test algorunner and the etl code.

The build logic is implemented in `Makefile`, and is invoked by
.github/workflow/build.yml. Moving forward, we can port this logic
to gerrit/blubber with (hopefully) reasonably low overhead.

The build status can be found at
- https://github.com/mirrys/ImageMatching/actions/workflows/build.yml
- https://github.com/mirrys/ImageMatching/workflows/build/badge.svg?branch=T275685-automate-pytest

A badge with the build status of the `main` branch has been added to `README.md`.

While the `Makefile` was built for use in a CI system, it will work on any *nix host that
satisfies the following dependencies:
- Java JDK8
- Python 3.7