### PR TITLE
Implement parsing of “instance of” fields in ImageMatching production datasets

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -12,6 +12,7 @@ def raw_data(spark_session):
                 "44444",
                 "Some page with suggestions",
                 '[{"image": "image1.jpg", "rating": 2.0, "note": "image was found in the following Wikis: ruwiki"}]',
+                None,
                 "arwiki",
                 "2020-12",
             ),
@@ -20,6 +21,7 @@ def raw_data(spark_session):
                 "Q56789",
                 "55555",
                 "Some page with no suggestion",
+                None,
                 None,
                 "arwiki",
                 "2020-12",
@@ -30,10 +32,12 @@ def raw_data(spark_session):
                 "523523",
                 "Some page with 3 suggestions",
                 '['
-                '   {"image": "image2.jpg", "rating": 2.0, "note": "image was found in the following Wikis: ruwiki"}, '
-                    '{"image": "image3.jpg", "rating": 1, "note": "image was in the Wikidata item"}, '
-                    '{"image": "image4.jpg", "rating": 3.0, "note": "image was found in the Commons category linked in the Wikidata item"}'
+                '{"image": "image2.jpg", "rating": 2.0, "note": "image was found in the following Wikis: ruwiki"}, '
+                '{"image": "image3.jpg", "rating": 1, "note": "image was in the Wikidata item"}, '
+                '{"image": "image4.jpg", "rating": 3.0, "note": "image was found in the Commons category linked in '
+                'the Wikidata item"} '
                 ']',
+                '{"entity-type":"item","numeric-id":577,"id":"Q577"}',
                 "enwiki",
                 "2020-12",
             ),

--- a/dataset_metrics/Dataset_metrics.ipynb
+++ b/dataset_metrics/Dataset_metrics.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "requested-karaoke",
+   "id": "collective-bargain",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -14,7 +14,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "provincial-southeast",
+   "id": "central-poland",
    "metadata": {
     "tags": [
      "parameters"
@@ -32,7 +32,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "incorporate-registration",
+   "id": "superb-oakland",
    "metadata": {},
    "source": [
     "### Total number of records (per wiki)"
@@ -41,7 +41,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ranking-gibraltar",
+   "id": "fifteen-restriction",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -56,7 +56,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dangerous-conservative",
+   "id": "demanding-protein",
    "metadata": {
     "scrolled": true
    },
@@ -68,7 +68,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "standard-special",
+   "id": "hollywood-royal",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -77,7 +77,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "romance-superintendent",
+   "id": "pretty-enterprise",
    "metadata": {},
    "source": [
     "### Population statistics"
@@ -86,7 +86,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "freelance-florence",
+   "id": "direct-recognition",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -98,7 +98,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "hispanic-standard",
+   "id": "optimum-seeking",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -108,7 +108,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "patent-scale",
+   "id": "political-selling",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -120,7 +120,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "metropolitan-keeping",
+   "id": "individual-smooth",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -131,7 +131,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "middle-hamilton",
+   "id": "registered-magazine",
    "metadata": {},
    "source": [
     "### Total number of images per page"
@@ -140,7 +140,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "distinguished-stranger",
+   "id": "rural-seller",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -155,7 +155,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "adopted-mexican",
+   "id": "ordinary-tracker",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -165,7 +165,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fifty-motel",
+   "id": "fifth-honor",
    "metadata": {},
    "source": [
     "#### Breakdown of the number of images being suggested for each page"
@@ -173,7 +173,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "deluxe-father",
+   "id": "sonic-astronomy",
    "metadata": {},
    "source": [
     "Keep in mind that pages without an image suggestion will apear as 1."
@@ -182,7 +182,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "accomplished-leather",
+   "id": "appreciated-glory",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -201,7 +201,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "undefined-childhood",
+   "id": "superior-acrobat",
    "metadata": {
     "scrolled": true
    },
@@ -215,7 +215,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dynamic-jacket",
+   "id": "guilty-observer",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -228,7 +228,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "excessive-intelligence",
+   "id": "institutional-remark",
    "metadata": {},
    "source": [
     "Breakdown of image suggestion data by confidence rating.\n",
@@ -238,7 +238,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "filled-dutch",
+   "id": "persistent-trading",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -253,7 +253,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "effective-thomson",
+   "id": "american-ready",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -263,7 +263,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cultural-defeat",
+   "id": "viral-piece",
    "metadata": {},
    "source": [
     "#### Get articles with more than 3 image suggestions\n",
@@ -274,7 +274,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "compressed-brooks",
+   "id": "postal-aquatic",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -297,7 +297,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "happy-navigator",
+   "id": "color-lexington",
    "metadata": {
     "scrolled": true
    },
@@ -309,7 +309,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dental-bennett",
+   "id": "particular-singles",
    "metadata": {},
    "source": [
     "### Size and counts of intermediate and final datasets"
@@ -318,7 +318,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "complete-glossary",
+   "id": "bright-manhattan",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -333,7 +333,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "numerical-bryan",
+   "id": "unable-performance",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -343,7 +343,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "packed-counter",
+   "id": "incident-particle",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -354,7 +354,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "instrumental-species",
+   "id": "improving-journalist",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -365,10 +365,8 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "modern-productivity",
-   "metadata": {
-    "scrolled": false
-   },
+   "id": "soviet-norfolk",
+   "metadata": {},
    "outputs": [],
    "source": [
     "result.plot(x=\"Wiki\",\n",
@@ -379,12 +377,39 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "revolutionary-power",
+   "metadata": {},
+   "source": [
+    "### Number of articles with and without valid \"instance of\""
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "worse-fleece",
+   "id": "healthy-bacteria",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "query = \"\"\"SELECT wiki_db, snapshot,\n",
+    "        COUNT(instance_of) AS with_instance_of,\n",
+    "        SUM(CASE WHEN instance_of IS NULL then 1 ELSE 0 END) AS without_instance_of\n",
+    "        FROM gmodena.imagerec_parquet\n",
+    "        WHERE snapshot = '2021-01'\n",
+    "        GROUP BY wiki_db, snapshot\n",
+    "        ORDER BY wiki_db\"\"\"\n",
+    "instance_of_metrics = spark.sql(query).toPandas()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "grand-ultimate",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "instance_of_metrics.to_csv(output_dir+\"/\"+\"Number of articles with and without valid instance_of\")"
+   ]
   }
  ],
  "metadata": {

--- a/dataset_metrics/Dataset_metrics.ipynb
+++ b/dataset_metrics/Dataset_metrics.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "collective-bargain",
+   "id": "impressed-fourth",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -14,7 +14,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "central-poland",
+   "id": "deluxe-mailman",
    "metadata": {
     "tags": [
      "parameters"
@@ -32,7 +32,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "superb-oakland",
+   "id": "improving-jonathan",
    "metadata": {},
    "source": [
     "### Total number of records (per wiki)"
@@ -41,7 +41,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fifteen-restriction",
+   "id": "engaged-inflation",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -56,7 +56,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "demanding-protein",
+   "id": "lucky-vocabulary",
    "metadata": {
     "scrolled": true
    },
@@ -68,7 +68,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "hollywood-royal",
+   "id": "activated-worker",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -77,7 +77,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "pretty-enterprise",
+   "id": "intimate-penny",
    "metadata": {},
    "source": [
     "### Population statistics"
@@ -86,7 +86,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "direct-recognition",
+   "id": "arabic-casting",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -98,7 +98,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "optimum-seeking",
+   "id": "friendly-leonard",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -108,7 +108,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "political-selling",
+   "id": "loose-throw",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -120,7 +120,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "individual-smooth",
+   "id": "neither-coating",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -131,7 +131,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "registered-magazine",
+   "id": "banner-criticism",
    "metadata": {},
    "source": [
     "### Total number of images per page"
@@ -140,7 +140,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "rural-seller",
+   "id": "lesbian-angel",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -155,7 +155,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ordinary-tracker",
+   "id": "polar-click",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -165,7 +165,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fifth-honor",
+   "id": "front-ratio",
    "metadata": {},
    "source": [
     "#### Breakdown of the number of images being suggested for each page"
@@ -173,7 +173,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "sonic-astronomy",
+   "id": "awful-stuart",
    "metadata": {},
    "source": [
     "Keep in mind that pages without an image suggestion will apear as 1."
@@ -182,7 +182,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "appreciated-glory",
+   "id": "neither-emphasis",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -201,7 +201,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "superior-acrobat",
+   "id": "assisted-startup",
    "metadata": {
     "scrolled": true
    },
@@ -215,7 +215,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "guilty-observer",
+   "id": "complicated-delay",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -228,7 +228,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "institutional-remark",
+   "id": "downtown-manner",
    "metadata": {},
    "source": [
     "Breakdown of image suggestion data by confidence rating.\n",
@@ -238,7 +238,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "persistent-trading",
+   "id": "generic-priority",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -253,7 +253,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "american-ready",
+   "id": "impressive-failure",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -263,7 +263,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "viral-piece",
+   "id": "executive-theory",
    "metadata": {},
    "source": [
     "#### Get articles with more than 3 image suggestions\n",
@@ -274,7 +274,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "postal-aquatic",
+   "id": "fiscal-poverty",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -297,7 +297,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "color-lexington",
+   "id": "metallic-visibility",
    "metadata": {
     "scrolled": true
    },
@@ -309,7 +309,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "particular-singles",
+   "id": "invalid-trader",
    "metadata": {},
    "source": [
     "### Size and counts of intermediate and final datasets"
@@ -318,7 +318,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bright-manhattan",
+   "id": "integrated-spell",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -333,7 +333,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "unable-performance",
+   "id": "apparent-marble",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -343,7 +343,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "incident-particle",
+   "id": "aquatic-selling",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -354,7 +354,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "improving-journalist",
+   "id": "supreme-monday",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -365,7 +365,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "soviet-norfolk",
+   "id": "green-intellectual",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -378,16 +378,17 @@
   },
   {
    "cell_type": "markdown",
-   "id": "revolutionary-power",
+   "id": "supposed-nigeria",
    "metadata": {},
    "source": [
-    "### Number of articles with and without valid \"instance of\""
+    "### Number of articles with and without valid \"instance of\"\n",
+    "Todo: Update snapshot and table name to be passed in parameters"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "healthy-bacteria",
+   "id": "regulation-rental",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -404,7 +405,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "grand-ultimate",
+   "id": "offensive-underwear",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/etl/raw2parquet.py
+++ b/etl/raw2parquet.py
@@ -1,13 +1,8 @@
 from pyspark.sql import SparkSession
-from pyspark.sql.types import StructType, StringType, IntegerType
-from pyspark.sql import Column, DataFrame
 from pyspark.sql import functions as F
 from schema import CsvDataset
 
 import argparse
-import sys
-import uuid
-import datetime
 
 spark = SparkSession.builder.getOrCreate()
 
@@ -46,4 +41,3 @@ if __name__ == "__main__":
     ).parquet(
         destination
     )  # Requires dynamic partitioning enabled
-

--- a/etl/schema.py
+++ b/etl/schema.py
@@ -1,4 +1,4 @@
-from pyspark.sql.types import StructType, StringType, IntegerType
+from pyspark.sql.types import StructType, StringType
 
 
 class CsvDataset:
@@ -17,4 +17,5 @@ class RawDataset(CsvDataset):
     schema = CsvDataset.schema.add("wiki_db", StringType(), True).add(
         "snapshot", StringType(), True
     )
-    recommendation_schema = "array<struct<image:string,note:string,rating:double>>"
+    top_candidates_schema = "array<struct<image:string,note:string,rating:double>>"
+    instance_of_schema = "struct<`entity-type`:string,`numeric-id`:bigint,id:string>"

--- a/etl/transform.py
+++ b/etl/transform.py
@@ -1,7 +1,7 @@
 from pyspark.sql import SparkSession
 from pyspark.sql import Column, DataFrame
 from pyspark.sql import functions as F
-from pyspark.sql.types import StructType, StringType, IntegerType
+from pyspark.sql.types import IntegerType
 from schema import RawDataset
 
 import argparse
@@ -9,8 +9,6 @@ import uuid
 import datetime
 
 spark = SparkSession.builder.getOrCreate()
-
-
 
 
 class ImageRecommendation:
@@ -46,9 +44,9 @@ class ImageRecommendation:
     def __init__(self, dataFrame: DataFrame):
         self.dataFrame = dataFrame
         if not dataFrame.schema == RawDataset.schema:
-           raise AttributeError(
+            raise AttributeError(
                f"Invalid schema. Expected '{RawDataset.schema}'. Got '{dataFrame.schema}"
-           )
+            )
 
     def transform(self) -> DataFrame:
         with_recommendations = (
@@ -56,7 +54,7 @@ class ImageRecommendation:
             .withColumn(
                 "data",
                 F.explode(
-                    F.from_json("top_candidates", RawDataset.recommendation_schema)
+                    F.from_json("top_candidates", RawDataset.top_candidates_schema)
                 ),
             )
             .select("*", "data.image", "data.rating", "data.note")

--- a/tests/test_etl.py
+++ b/tests/test_etl.py
@@ -16,7 +16,7 @@ def test_etl(raw_data):
                     "page_title",
                     "image_id",
                     "confidence_rating",
-                    "instance_of_id",
+                    "instance_of",
                     "source",
                 }
             )
@@ -50,12 +50,12 @@ def test_etl(raw_data):
     )
 
     # Instance_of json is correctly parsed
-    expected_instance_of_id = "Q577"
+    expected_instance_of = "Q577"
     rows = (
-        ddf.where(F.col("instance_of_id") != "null")
-        .select("instance_of_id")
+        ddf.where(F.col("instance_of") != "null")
+        .select("instance_of")
         .distinct()
         .collect()
     )
     assert len(rows) == 1
-    assert rows[0]["instance_of_id"] == expected_instance_of_id
+    assert rows[0]["instance_of"] == expected_instance_of

--- a/tests/test_etl.py
+++ b/tests/test_etl.py
@@ -16,6 +16,7 @@ def test_etl(raw_data):
                     "page_title",
                     "image_id",
                     "confidence_rating",
+                    "instance_of_id",
                     "source",
                 }
             )
@@ -47,3 +48,14 @@ def test_etl(raw_data):
         .count()
         == 0
     )
+
+    # Instance_of json is correctly parsed
+    expected_instance_of_id = "Q577"
+    rows = (
+        ddf.where(F.col("instance_of_id") != "null")
+        .select("instance_of_id")
+        .distinct()
+        .collect()
+    )
+    assert len(rows) == 1
+    assert rows[0]["instance_of_id"] == expected_instance_of_id


### PR DESCRIPTION
The spark job we use to generate production datasets needs to parse the new "instance of fields"

Acceptance criteria
- [x] Logic to parse the "instance of" json blob is implemented
- [x] Tests for this capability have been added
- [x] The number of articles with and without valid "instance of" metadata is known (add metric)