### PR TITLE
T277552 project jdata store as parquet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,4 +20,4 @@ flake8:	venv
 	. venv/bin/activate; flake8 *.py dataset_metrics/ etl/ tests/ --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
 test:	venv
-	. venv/bin/activate; PYTHONPATH=etl pytest --cov etl tests/
+	. venv/bin/activate; PYTHONPATH=${PYTHONPATH}:etl/ pytest --cov etl tests/

--- a/Makefile
+++ b/Makefile
@@ -20,4 +20,4 @@ flake8:	venv
 	. venv/bin/activate; flake8 *.py dataset_metrics/ etl/ tests/ --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
 test:	venv
-	. venv/bin/activate; pytest --cov etl tests/
+	. venv/bin/activate; PYTHONPATH=etl pytest --cov etl tests/

--- a/README.md
+++ b/README.md
@@ -49,15 +49,38 @@ hywiki_2020-12-28.ipynb  hywiki_2020-12-28_wd_image_candidates.tsv
 `etl` contains [pyspark](https://spark.apache.org/docs/latest/api/python/index.html) utilities to transform the 
 algo raw output into a _production dataset_ that will be consumed by a service. 
 
-The transform etl can be run on a local cluster with:
-```python
-spark2-submit etl/transform.py <raw data> <production data>
+### TSV to parquet
+`raw2parquet.py` is a job that loads a tsv file (model output), converts it to
+parquet, and stores it to HDFS (or local) using the `wiki_db=wiki/snapshot=YYYY-MM` 
+partitioning scheme.
+```bash
+spark2-submit --properties-file conf/spark.properties --files etl/schema.py etl/raw2parquet.py \
+    --wiki <wiki name> \
+    --snapshot <YYYY-MM> \
+    --source <raw data> \
+    --destination <production data>
+```
+
+### Production dataset
+
+`transform.py` parses raw model output and tansforms it to production data,
+and stores it to HDFS (or local) using the `wiki=wiki/snapshot=YYYY-MM` partitioning scheme.
+ 
+```bash
+spark2-submit --files etl/schema.py etl/transform.py \
+    --snapshot <YYYY-MM> \
+    --source <raw data> \
+    --destination <production data>
 ```
 
 `conf/spark.properties` provides default settings to run the ETL as a [regular size spark job](https://wikitech.wikimedia.org/wiki/Analytics/Systems/Cluster/Spark#Spark_Resource_Settings) on WMF's Analytics cluster.
 
-```python
-spark2-submit --properties-file conf/spark.properties etl/transform.py <raw data> <production data>
+```bash
+spark2-submit --properties-file conf/spark.properties --files etl/schema.py etl/transform.py \
+    --wiki <wiki name> \
+    --snapshot <YYYY-MM> \
+    --source <raw data> \
+    --destination <production data>
 ```
 
 ## Metrics collection

--- a/algorithm.ipynb
+++ b/algorithm.ipynb
@@ -539,7 +539,7 @@
     "        else:\n",
     "            top_candidates.append(None)\n",
     "    data_small[wiki]['top_candidates']=top_candidates\n",
-    "    data_small[wiki][['item_id','page_id','page_title','top_candidates']].to_csv(output_dir+'/'+wiki+'_'+snapshot+'_wd_image_candidates.tsv',sep='\\t')"
+    "    data_small[wiki][['item_id','page_id','page_title','top_candidates', 'instanceof']].to_csv(output_dir+'/'+wiki+'_'+snapshot+'_wd_image_candidates.tsv',sep='\\t')"
    ]
   }
  ],
@@ -560,7 +560,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.2"
+   "version": "3.7.3"
   },
   "toc-showtags": true
  },

--- a/conftest.py
+++ b/conftest.py
@@ -12,6 +12,7 @@ def raw_data(spark_session):
                 "44444",
                 "Some page with suggestions",
                 '[{"image": "image1.jpg", "rating": 2.0, "note": "image was found in the following Wikis: ruwiki"}]',
+                "",
                 "arwiki",
                 "2020-12",
             ),
@@ -21,6 +22,7 @@ def raw_data(spark_session):
                 "55555",
                 "Some page with no suggestion",
                 None,
+                "",
                 "arwiki",
                 "2020-12",
             ),
@@ -34,6 +36,7 @@ def raw_data(spark_session):
                     '{"image": "image3.jpg", "rating": 1, "note": "image was in the Wikidata item"}, '
                     '{"image": "image4.jpg", "rating": 3.0, "note": "image was found in the Commons category linked in the Wikidata item"}'
                 ']',
+                "",
                 "enwiki",
                 "2020-12",
             ),

--- a/ddl/external_imagerec.hql
+++ b/ddl/external_imagerec.hql
@@ -11,26 +11,19 @@
 
 USE ${hiveconf:username};
 
-CREATE EXTERNAL TABLE IF NOT EXISTS `imagerec`(
+CREATE EXTERNAL TABLE IF NOT EXISTS `imagerec` (
   `pandas_idx` string,
   `item_id` string,
   `page_id` string,
   `page_title` string,
-  `top_candidates` string)
+  `top_candidates` string,
+  `instance_of` string)
 PARTITIONED BY (
   `wiki_db` string,
   `snapshot` string)
-ROW FORMAT SERDE
-  'org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe'
-WITH SERDEPROPERTIES (
-  'field.delim'='\t',
-  'serialization.format'='\t')
-STORED AS INPUTFORMAT
-  'org.apache.hadoop.mapred.TextInputFormat'
-OUTPUTFORMAT
-  'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'
+STORED AS PARQUET
 LOCATION
-  'hdfs://analytics-hadoop/user/${hiveconf:username}/imagerec/data'
+  'hdfs://analytics-hadoop/user/${hiveconf:username}/imagerec'
 TBLPROPERTIES ("skip.header.line.count"="1");
 
 -- Update partition metadata

--- a/etl/raw2parquet.py
+++ b/etl/raw2parquet.py
@@ -1,0 +1,49 @@
+from pyspark.sql import SparkSession
+from pyspark.sql.types import StructType, StringType, IntegerType
+from pyspark.sql import Column, DataFrame
+from pyspark.sql import functions as F
+from schema import CsvDataset
+
+import argparse
+import sys
+import uuid
+import datetime
+
+spark = SparkSession.builder.getOrCreate()
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Transform raw algo output to production datasets"
+    )
+    parser.add_argument("--snapshot", help="Montlhy snapshot date (YYYY-MM)")
+    parser.add_argument("--wiki", help="Wiki name")
+    parser.add_argument("--source", help="Source dataset path")
+    parser.add_argument("--destination", help="Destination path")
+
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+
+    snapshot = args.snapshot
+    source = args.source
+    destination = args.destination
+    wiki = args.wiki
+
+    csv_df = (
+        (
+            spark.read.options(delimiter="\t", header=False, escape='"')
+            .schema(CsvDataset.schema)
+            .csv(source)
+        )
+        .withColumn("wiki_db", F.lit(wiki))
+        .withColumn("snapshot", F.lit(snapshot))
+    )
+    csv_df.coalesce(1).write.partitionBy("wiki_db", "snapshot").mode(
+        "overwrite"
+    ).parquet(
+        destination
+    )  # Requires dynamic partitioning enabled
+

--- a/etl/schema.py
+++ b/etl/schema.py
@@ -1,0 +1,20 @@
+from pyspark.sql.types import StructType, StringType, IntegerType
+
+
+class CsvDataset:
+    schema = (
+        StructType()
+        .add("pandas_idx", StringType(), True)
+        .add("item_id", StringType(), True)
+        .add("page_id", StringType(), True)
+        .add("page_title", StringType(), True)
+        .add("top_candidates", StringType(), True)
+        .add("instance_of", StringType(), True)
+    )
+
+
+class RawDataset(CsvDataset):
+    schema = CsvDataset.schema.add("wiki_db", StringType(), True).add(
+        "snapshot", StringType(), True
+    )
+    recommendation_schema = "array<struct<image:string,note:string,rating:double>>"


### PR DESCRIPTION
Project `instanceof` metadata in the model output.

This PR adds change to export metadata related to the "instance of" 
property of a q item. This information stored as an appended to column to the model output,
and propagates to HDFS and Hive `imagerec` datasets.

This PR also adds a spark job to upload and convert model output to `Parquet`. This has
been done to facilitate interop with spark, and handle schema migrations.

Closes: https://phabricator.wikimedia.org/T277552