### PR TITLE
Bugfix: save all unillustrated articles.

### DIFF
--- a/algorithm.ipynb
+++ b/algorithm.ipynb
@@ -372,7 +372,7 @@
     "    print(\"number of articles items with Wikidata Commons Category: \"+str(len(commonscategory[wiki])))\n",
     "    print(\"number of articles items with Language Links: \"+str(len(lanimages[wiki])))\n",
     "    ####\n",
-    "    allimages[wiki]=qids_and_properties[wiki][(qids_and_properties[wiki]['hasimage'].astype(str).ne('None')) | (qids_and_properties[wiki]['lan_images'].astype(str).ne('None')) | (qids_and_properties[wiki]['category_imagelist'].astype(str).ne('None'))]\n"
+    "    allimages[wiki]=qids_and_properties[wiki]"
    ]
   },
   {


### PR DESCRIPTION
Don't exclude any image source when building`allimages`.

Fixes https://phabricator.wikimedia.org/T278571