### PR TITLE
Filter image suggestions detected as "placeholder images"

### DIFF
--- a/algorithm.ipynb
+++ b/algorithm.ipynb
@@ -61,7 +61,10 @@
     "\n",
     "# A spark session type determines the resource pool\n",
     "# to initialise on yarn\n",
-    "spark_session_type = 'regular'"
+    "spark_session_type = 'regular'\n",
+    "\n",
+    "# Name of placeholder images parquet file\n",
+    "image_placeholders_file = 'image_placeholders'"
    ]
   },
   {
@@ -126,7 +129,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "image_placeholders = spark.read.parquet(\"image_placeholders\")\n",
+    "image_placeholders = spark.read.parquet(image_placeholders_file)\n",
     "image_placeholders.createOrReplaceTempView(\"image_placeholders\")"
    ]
   },

--- a/algorithm.ipynb
+++ b/algorithm.ipynb
@@ -126,6 +126,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "image_placeholders = spark.read.parquet(\"image_placeholders\")\n",
+    "image_placeholders.createOrReplaceTempView(\"image_placeholders\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "def get_threshold(wiki_size):\n",
     "    #change th to optimize precision vs recall. recommended val for accuracy = 5\n",
     "    sze, th, lim = 50000, 15, 4 \n",
@@ -290,6 +300,8 @@
     "     on qid_props.commonscategory=mc.cl_to\n",
     "     join wmf_raw.mediawiki_page mp\n",
     "     on mp.page_id=mc.cl_from\n",
+    "     LEFT ANTI JOIN image_placeholders\n",
+    "     on image_placeholders.page_title = mp.page_title\n",
     "     WHERE mp.wiki_db ='commonswiki'\n",
     "     AND mp.snapshot='\"\"\"+short_snapshot+\"\"\"'\n",
     "     AND mp.page_namespace=6\n",
@@ -317,6 +329,8 @@
     "     AND wipl.page_id=pp.pp_page\n",
     "     AND wipl.wiki_db=pp.wiki_db\n",
     "     AND mp.page_title=pp.pp_value\n",
+    "     LEFT ANTI JOIN image_placeholders\n",
+    "     ON image_placeholders.page_title = pp.pp_value\n",
     "     WHERE wipl.wiki_db !='\"\"\"+wiki+\"\"\"'\n",
     "     AND wipl.snapshot='\"\"\"+snapshot+\"\"\"'\n",
     "     AND wipl.page_namespace=0\n",
@@ -569,7 +583,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.7.1"
   },
   "toc-showtags": true
  },

--- a/placeholder_images.py
+++ b/placeholder_images.py
@@ -49,7 +49,9 @@ class PlaceholderImages:
                              AND mc.snapshot='""" + self.snapshot + """'
                              AND mc.wiki_db ='commonswiki'
                             """)
-        image_placeholders.coalesce(1).write.mode("overwrite").parquet("image_placeholders")
+
+        # Using repartition instead of coalesce because coalesce caused a spark memory error
+        image_placeholders.repartition(1).write.mode("overwrite").parquet("image_placeholders")
 
 
 if __name__ == "__main__":
@@ -63,3 +65,4 @@ if __name__ == "__main__":
     placeholder_images = PlaceholderImages(args.snapshot, args.username)
 
     placeholder_images.run()
+    spark.stop()

--- a/placeholder_images.py
+++ b/placeholder_images.py
@@ -1,0 +1,65 @@
+from wmfdata.spark import get_session
+import argparse
+import requests
+import pandas as pd
+import numpy as np
+import findspark
+
+findspark.init('/usr/lib/spark2')
+
+spark = get_session(type='regular', app_name="ImageRec-DEV Training")
+
+
+class PlaceholderImages:
+    def __init__(self, snapshot):
+        self.snapshot = snapshot
+
+    @staticmethod
+    def get_placeholder_category():
+        try:
+            r = requests.get('https://petscan.wmflabs.org/', params={'psid': '18699732', 'format': 'json'})
+            r.raise_for_status()
+            response_json = r.json()
+            results = response_json['*'][0]['a']['*']
+            plhd_cat = pd.DataFrame(np.array([[r['id'], r['title']] for r in results]),
+                                    columns=['id', 'title'])
+        except requests.exceptions.RequestException:
+            return None
+        else:
+            return plhd_cat
+
+    def run(self):
+        plhd_cat = self.get_placeholder_category()
+
+        if plhd_cat is None:
+            plhd_table = 'aikochou.placeholder_category'
+        else:
+            sdf = spark.createDataFrame(plhd_cat)
+            sdf.createOrReplaceTempView('placeholder_category')
+            plhd_table = 'placeholder_category'
+
+        image_placeholders = spark.sql("""SELECT cl_from, cl_to, cl_type, page_title
+                             FROM wmf_raw.mediawiki_categorylinks mc
+                             JOIN wmf_raw.mediawiki_page mp
+                             ON mp.page_id = cl_from
+                             JOIN """ + plhd_table + """ pc
+                             ON mc.cl_to = pc.title
+                             WHERE mp.wiki_db = 'commonswiki'
+                             AND mp.snapshot='""" + self.snapshot + """'
+                             AND mp.page_namespace=6
+                             AND mp.page_is_redirect=0
+                             AND mc.snapshot='""" + self.snapshot + """'
+                             AND mc.wiki_db ='commonswiki'
+                            """)
+        image_placeholders.write.parquet("image_placeholders")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='Executes placeholder_images with parameters. ' +
+                                                 'Ex: python3 placeholder_images.py 2021-02')
+    parser.add_argument('snapshot', help='Snapshot date. Ex: 2021-02')
+
+    args = parser.parse_args()
+    placeholder_images = PlaceholderImages(args.snapshot)
+
+    placeholder_images.run()

--- a/placeholder_images.py
+++ b/placeholder_images.py
@@ -1,18 +1,16 @@
-from wmfdata.spark import get_session
+from pyspark.sql import SparkSession
 import argparse
 import requests
 import pandas as pd
 import numpy as np
-import findspark
 
-findspark.init('/usr/lib/spark2')
-
-spark = get_session(type='regular', app_name="ImageRec-DEV Training")
+spark = SparkSession.builder.getOrCreate()
 
 
 class PlaceholderImages:
-    def __init__(self, snapshot):
+    def __init__(self, snapshot, username):
         self.snapshot = snapshot
+        self.username = username
 
     @staticmethod
     def get_placeholder_category():
@@ -32,7 +30,7 @@ class PlaceholderImages:
         plhd_cat = self.get_placeholder_category()
 
         if plhd_cat is None:
-            plhd_table = 'aikochou.placeholder_category'
+            plhd_table = f'{self.username}.placeholder_category'
         else:
             sdf = spark.createDataFrame(plhd_cat)
             sdf.createOrReplaceTempView('placeholder_category')
@@ -51,15 +49,17 @@ class PlaceholderImages:
                              AND mc.snapshot='""" + self.snapshot + """'
                              AND mc.wiki_db ='commonswiki'
                             """)
-        image_placeholders.write.parquet("image_placeholders")
+        image_placeholders.coalesce(1).write.mode("overwrite").parquet("image_placeholders")
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Executes placeholder_images with parameters. ' +
                                                  'Ex: python3 placeholder_images.py 2021-02')
     parser.add_argument('snapshot', help='Snapshot date. Ex: 2021-02')
+    parser.add_argument('username', nargs='?', default='aikochou',
+                        help='Fallback database name to get placeholder_category table. Defaults to: aikochou')
 
     args = parser.parse_args()
-    placeholder_images = PlaceholderImages(args.snapshot)
+    placeholder_images = PlaceholderImages(args.snapshot, args.username)
 
     placeholder_images.run()

--- a/publish.sh
+++ b/publish.sh
@@ -64,6 +64,15 @@ $(pwd)/runs/${run_id}"
 spark_config=runs/$run_id/regular.spark.properties
 cat conf/spark.properties.template /usr/lib/spark2/conf/spark-defaults.conf > ${spark_config}
 
+# Generate placeholder_images parquet file
+echo "Generating placeholder_image parquet file"
+STARTTIME=${SECONDS}
+python placeholder_images.py ${monthly_snapshot}
+ENDTIME=${SECONDS}
+metric_name=metrics.placeholder_images.${monthly_snapshot}.seconds
+timestamp=$(date +%s)
+echo "${timestamp},$(($ENDTIME - $STARTTIME))" >> ${metrics_dir}/${metric_name}
+
 # TODO(gmodena, 2021-02-02): 
 # Passing one wiki at a time to get a feeling for runtime deltas (to some degree, we could get this info from parsing hdfs snapshots).
 # We could pass the whole list at algorunner.py at once,

--- a/publish.sh
+++ b/publish.sh
@@ -67,7 +67,7 @@ cat conf/spark.properties.template /usr/lib/spark2/conf/spark-defaults.conf > ${
 # Generate placeholder_images parquet file
 echo "Generating placeholder_image parquet file"
 STARTTIME=${SECONDS}
-python placeholder_images.py ${monthly_snapshot}
+spark2-submit --properties-file ${spark_config} placeholder_images.py ${monthly_snapshot}
 ENDTIME=${SECONDS}
 metric_name=metrics.placeholder_images.${monthly_snapshot}.seconds
 timestamp=$(date +%s)


### PR DESCRIPTION
 - [X] As a user of the Image Suggestion API, when I make a request for image suggestions, I expect that all images detected as a "placeholder image" have been filtered out
     - [X] Miriam validation query has been newly applied (see https://phabricator.wikimedia.org/T277828#6957015), and results should reflect 0 "placeholder images' found for representative wikis
- [x] A static list of "placeholder images" has been generated and stored in HDFS
- [x] The algorithm notebook has been updated to filter out "placeholder images"