### PR TITLE
Remove the language filter for wikidata labels.

### DIFF
--- a/algorithm.ipynb
+++ b/algorithm.ipynb
@@ -77,7 +77,7 @@
     "# Under the hood the library uses findspark to initialise\n",
     "# Spark's environment. pyspark imports will be available \n",
     "# after initialisation\n",
-    "spark = get_session(type='regular', app_name=\"ImageRec-DEV Training\")\n",
+    "spark = get_session(type='regular', app_name=\"ImageRec-DEV Training\", extra_settings={'spark.driver.memory': '2048'})\n",
     "import pyspark\n",
     "import pyspark.sql"
    ]
@@ -301,7 +301,6 @@
     "     LATERAL VIEW explode(labels) t AS label_lang,label_val\n",
     "     LATERAL VIEW OUTER explode(claims) c AS claim\n",
     "     WHERE typ='item'\n",
-    "     AND t.label_lang='\"\"\"+label_lang+\"\"\"'\n",
     "     AND snapshot='\"\"\"+snapshot+\"\"\"'\n",
     "     AND claim.mainSnak.property in ('P18','P31','P373')\n",
     "     GROUP BY id,label_val\n",
@@ -597,7 +596,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.1"
+   "version": "3.7.3"
   },
   "toc-showtags": true
  },

--- a/algorithm.ipynb
+++ b/algorithm.ipynb
@@ -77,7 +77,7 @@
     "# Under the hood the library uses findspark to initialise\n",
     "# Spark's environment. pyspark imports will be available \n",
     "# after initialisation\n",
-    "spark = get_session(type='regular', app_name=\"ImageRec-DEV Training\", extra_settings={'spark.driver.memory': '2048'})\n",
+    "spark = get_session(type='regular', app_name=\"ImageRec-DEV Training\", extra_settings={'spark.driver.memory': '2048M'})\n",
     "import pyspark\n",
     "import pyspark.sql"
    ]

--- a/algorithm.ipynb
+++ b/algorithm.ipynb
@@ -77,9 +77,23 @@
     "# Under the hood the library uses findspark to initialise\n",
     "# Spark's environment. pyspark imports will be available \n",
     "# after initialisation\n",
-    "spark = get_session(type='regular', app_name=\"ImageRec-DEV Training\", extra_settings={'spark.driver.memory': '2048M'})\n",
+    "# spark = get_session(type='regular', extra_settings={'spark.driver.maxResultSize': '2048M'})\n",
+    "import os\n",
+    "import findspark\n",
+    "SPARK_HOME = os.environ.get(\"SPARK_HOME\", \"/usr/lib/spark2\")\n",
+    "findspark.init(SPARK_HOME)\n",
+    "findspark._add_to_submit_args('--driver-memory 64G --conf \"spark.driver.extraJavaOptions=-XX:+UseG1GC -XX:+PrintGCDetails -XX:+PrintGCTimeStamps\"')\n",
+    "master = 'yarn'\n",
+    "app_name = 'gmodena-imagematching-driver-highmem'\n",
     "import pyspark\n",
-    "import pyspark.sql"
+    "from pyspark.sql import SparkSession\n",
+    "\n",
+    "spark = (\n",
+    "        SparkSession.builder\n",
+    "        .master(master)\n",
+    "        .config('spark.driver.maxResultSize', '2048M')\n",
+    "        .appName(app_name)\n",
+    "    ).getOrCreate()"
    ]
   },
   {


### PR DESCRIPTION
Bump Spark Driver memory to acount for larger results set.
The memory upper bound was found to allow the job to complete on enwiki.

This change is experimental, and meant to enable analysis/experimentation.