### PR TITLE
Update spark dep in makefile

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,11 +28,11 @@ jobs:
         java-version: adopt@1.8
     - name: Install Apache Spark
       run: |
-        # This command will install vanilla spark under ./spark-2.4.7-bin-hadoop2.7
+        # This command will install vanilla spark under ./spark-2.4.8-bin-hadoop2.7
         make install_spark
     - name: Test with pytest
       run: |
-        export SPARK_HOME=$(pwd)/spark-2.4.7-bin-hadoop2.7
+        export SPARK_HOME=$(pwd)/spark-2.4.8-bin-hadoop2.7
         export PYTHONPATH=${SPARK_HOME}/python:${SPARK_HOME}/python/lib/py4j-0.10.7-src.zip:${PYTHONPATH}
         export PATH=${PATH}:${SPARK_HOME}/bin:${SPARK_HOME}/sbin
         make test

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
-spark_version := 2.4.7
+spark_version := 2.4.8
 hadoop_version := 2.7
 spark_home := spark-${spark_version}-bin-hadoop${hadoop_version}
-spark_tgz_url := http://apachemirror.wuchna.com/spark/spark-${spark_version}/${spark_home}.tgz
+spark_tgz_url := https://downloads.apache.org/spark/spark-${spark_version}/${spark_home}.tgz
 
 venv: requirements.txt
 	test -d venv || python3 -m venv venv


### PR DESCRIPTION
PR for https://phabricator.wikimedia.org/T288114.

Our CI points to a Spark tarball that does not exist anymore.  This change points to the currently available Spark 2.x
tarball in apache mirrors, which means a bump from 2.4.7 to 2.4.8.