### PR TITLE
Fix broken spark mirror host.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 spark_version := 2.4.7
 hadoop_version := 2.7
 spark_home := spark-${spark_version}-bin-hadoop${hadoop_version}
-spark_tgz_url := http://apachemirror.wuchna.com/spark/spark-${spark_version}/${spark_home}.tgz
+spark_tgz_url := https://archive.apache.org/dist/spark/spark-${spark_version}/${spark_home}.tgz
 
 venv: requirements.txt
 	test -d venv || python3 -m venv venv


### PR DESCRIPTION
The old apache mirror is not available anymore, causing the
build process to fail with:
unable to resolve host address ‘apachemirror.wuchna.com’