### PR TITLE
WIP: Convert the model ipython notebook to a script.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,9 @@ jobs:
     - name: Convert notebook to python script
       run: |
         make py
+        mkdir -p ima/scripts/
+        mv algorithm.py ima/scripts
     - uses: actions/upload-artifact@v2
       with:
-        name: algorithm.py
+        name: algorithm
         path: ima/scripts/algorithm.py

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,3 +36,10 @@ jobs:
         export PYTHONPATH=${SPARK_HOME}/python:${SPARK_HOME}/python/lib/py4j-0.10.7-src.zip:${PYTHONPATH}
         export PATH=${PATH}:${SPARK_HOME}/bin:${SPARK_HOME}/sbin
         make test
+    - name: Convert notebook to python script
+      run: |
+        make py
+    - uses: actions/upload-artifact@v2
+      with:
+        name: algorithm.py
+        path: ima/scripts/algorithm.py

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,11 +47,11 @@ jobs:
         path: ima/scripts/algorithm.py
 
     - name: add artifact links to pull request and related issues step
-        uses: tonyhallett/artifacts-url-comments@v1.1.0
-        env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-            prefix: The build action generated the following artifacts
-            format: name
-            addTo: pullandissues
+      uses: tonyhallett/artifacts-url-comments@v1.1.0
+      env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+          prefix: The build action generated the following artifacts
+          format: name
+          addTo: pullandissues
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,12 +46,3 @@ jobs:
         name: algorithm
         path: ima/scripts/algorithm.py
 
-    - name: add artifact links to pull request and related issues step
-      uses: tonyhallett/artifacts-url-comments@v1.1.0
-      env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-          prefix: The build action generated the following artifacts
-          format: name
-          addTo: pullandissues
-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,3 +45,13 @@ jobs:
       with:
         name: algorithm
         path: ima/scripts/algorithm.py
+
+    - name: add artifact links to pull request and related issues step
+        uses: tonyhallett/artifacts-url-comments@v1.1.0
+        env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+            prefix: The build action generated the following artifacts
+            format: name
+            addTo: pullandissues
+

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ spark_version := 2.4.8
 hadoop_version := 2.7
 spark_home := spark-${spark_version}-bin-hadoop${hadoop_version}
 spark_tgz_url := https://downloads.apache.org/spark/spark-${spark_version}/${spark_home}.tgz
+ima_notebook := algorithm.ipynb
 
 venv: requirements.txt
 	test -d venv || python3 -m venv venv
@@ -21,3 +22,7 @@ flake8:	venv
 
 test:	venv
 	. venv/bin/activate; PYTHONPATH=${PYTHONPATH}:etl/ pytest --cov etl tests/
+
+py:	venv
+	# nbconvert output is saved as <basename>.py
+	. venv/bin/activate; jupyter nbconvert ${ima_notebook} --to script

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pytest==6.2.2
 pytest-spark==0.6.0
 pytest-cov==2.10.1
 flake8==3.8.4
+jupyter==1.0.0


### PR DESCRIPTION
This WIP adds the capability to extract a python script from the notebook,
and save it as build artifact in Github. I open this PR to collect feedback / discuss possible approaches to releasing the notebook code in a format consumable in non-interactive mode.

The changes add a new `py` target to `Makefile` (`make py`) that runs `nbconvert` on the algo notebook. The resulting script can be executed on spark with the canonical `spark-submit [...] algorithm.py`.

I wanted to experiment with a flow that, after a successful build, publishes the resulting artifact to a generally available location. 

I've been toying with CI and added `make py` to the github workflow. With this change we'd generate a new script at each PR / git push, that is available under the Artifacts pane of the Action UI.

Unfortunately there is no straightforward way to generate the artifact URL for remote consumption.

Next I want to explore the capabilities of our internal Gitlab (pipelines are enabled), and eventually move the codebase there.